### PR TITLE
sketch geometry as WKT

### DIFF
--- a/vtzero/cvtzero.pxd
+++ b/vtzero/cvtzero.pxd
@@ -27,7 +27,10 @@ cdef extern from 'vtzero/geometry.hpp' namespace 'vtzero':
     ctypedef struct point:
         int32_t x
         int32_t y
-    cdef decode_point_geometry(const geometry geometry, bool strict, geom_handler)
+    
+    #cdef decode_point_geometry(const geometry geometry, bool strict, geom_handler)
+    # Use generic decode geometry
+    cdef decode_geometry(const geometry geometry, bool strict, geom_handler)
 
 
 cdef extern from 'vtzero/layer.hpp' namespace 'vtzero':

--- a/vtzero/tile.pyx
+++ b/vtzero/tile.pyx
@@ -96,6 +96,33 @@ cdef class VectorFeature:
     def geometry_type(self):
         return self.feature.geometry_type()
 
+#    @property
+#    def geometry(self):
+#        cdef GeometryAsWKT handler = GeometryAsWKT()
+#        cvtzero.decode_geometry(self.feature.geometry(), True, handler)
+#        return handler.data
+#
+# NOT TESTED - NEED PROPER CYTHON code 
+# The idea of this class is to return the geometry as a WTK
+# roughtly like https://github.com/mapbox/vtzero/blob/0a0afc97d78c477f49e737da4166bb6927da7a5e/examples/vtzero-show.cpp#L20-L93
+#cdef class GeometryAsWKT:
+#
+#    cdef char* data
+#    cdef points_begin(self, uint32_t count):
+#        pass
+#    
+#    cdef points_point(self, cvtzero.point point):
+#        self.data = b"POINT ("
+#        self.data += point.x
+#        self.data += b","
+#        self.data += point.y
+#        self.data += b")"
+#
+#    cdef points_end(self):
+#        pass
+#
+#    ADD POLYGON
+#    ADD LINESTRING
 
 cdef class Tile:
 


### PR DESCRIPTION
This is a rough start for adding `feature.geometry` method. 

The idea is to do something similar that https://github.com/mapbox/vtzero/blob/0a0afc97d78c477f49e737da4166bb6927da7a5e/examples/vtzero-show.cpp#L20-L93 but to return a WKT string. 

My cython/C skills are almost inexistant, so not sure if I'll be able to make it work

@yohanboniface you already try to implement this method but using `decode_point_geometry`. Was it working for you ? I'm getting errors like 
```
geometry.hpp:245:54: error: no member named 'points_begin'
``` 
